### PR TITLE
Bug fix in case a keyboard press was never released during the recording

### DIFF
--- a/eeg_flow/io.py
+++ b/eeg_flow/io.py
@@ -345,6 +345,9 @@ def add_keyboard_buttons(raw: BaseRaw, eeg_stream: dict, keyboard_stream: dict) 
     description = list()
 
     for button in unique_buttons:
+        temp_onset_lsl = None
+        temp_description = None
+
         for k, event in enumerate(data):
             if button not in event:
                 continue
@@ -356,10 +359,12 @@ def add_keyboard_buttons(raw: BaseRaw, eeg_stream: dict, keyboard_stream: dict) 
             # released defines durations
             if "released" in event:
                 # values for the onset are only relevant if a released event exists
+                if temp_onset_lsl is None and temp_description is None:
+                    continue
                 onset_lsl.append(temp_onset_lsl)
                 description.append(temp_description)
-                temp_onset_lsl = -1
-                temp_description = -1
+                temp_onset_lsl = None
+                temp_description = None
 
                 duration.append(timestamps[k] - onset_lsl[-1])
 

--- a/eeg_flow/io.py
+++ b/eeg_flow/io.py
@@ -351,10 +351,16 @@ def add_keyboard_buttons(raw: BaseRaw, eeg_stream: dict, keyboard_stream: dict) 
 
             # pressed defines onset and description
             if "pressed" in event:
-                onset_lsl.append(timestamps[k])
-                description.append(button)
+                temp_onset_lsl = timestamps[k]
+                temp_description = button
             # released defines durations
             if "released" in event:
+                # values for the onset are only relevant if a released event exists
+                onset_lsl.append(temp_onset_lsl)
+                description.append(temp_description)
+                temp_onset_lsl = -1
+                temp_description = -1
+
                 duration.append(timestamps[k] - onset_lsl[-1])
 
     # convert onset to time relative to raw instance


### PR DESCRIPTION
Ignore a pressed event if a release event does not exist, to avoid discrep in length while creating the keyboard annotations